### PR TITLE
Enable backend-configurable payout table

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ For end-to-end tests powered by [Playwright](https://playwright.dev/):
    pnpm test:e2e
    ```
 
+### Backend configuration
+
+The game loads payout multipliers from a configurable endpoint. Set `VITE_CONFIG_ENDPOINT`
+to your backend URL and `VITE_CONFIG_TOKEN` if the endpoint requires authentication.
+When running on a server, the built-in `/api/config` route will read `BIN_PAYOUTS_JSON`
+from environment variables to override the default table. Use HTTPS and protected
+tokens to ensure only authorized backends can modify the payouts.
+
 ### Benchmark
 
 A hidden page is only available in local dev environment to benchmark the payout probabilities and expected values. I used this page to tune the parameters of the matter-js physics engine and control the expected payout.

--- a/src/lib/components/BinsDistribution.svelte
+++ b/src/lib/components/BinsDistribution.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { binPayouts, binProbabilitiesByRowCount, type RowCount } from '$lib/constants/game';
+  import { binProbabilitiesByRowCount, type RowCount } from '$lib/constants/game';
+  import { binPayouts } from '$lib/stores/config';
   import { binProbabilities, rowCount } from '$lib/stores/game';
   import { RiskLevel } from '$lib/types';
   import { dotProduct } from '$lib/utils/numbers';
@@ -18,7 +19,7 @@
     rowCount: RowCount,
     riskLevel: RiskLevel,
     binProbabilities: number[],
-  ) => dotProduct(binPayouts[rowCount][riskLevel], binProbabilities);
+  ) => dotProduct($binPayouts[rowCount][riskLevel], binProbabilities);
 
   const initChart: Action<
     HTMLCanvasElement,

--- a/src/lib/components/Plinko/BinsRow.svelte
+++ b/src/lib/components/Plinko/BinsRow.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { binColorsByRowCount, binPayouts } from '$lib/constants/game';
+  import { binColorsByRowCount } from '$lib/constants/game';
+  import { binPayouts } from '$lib/stores/config';
   import { plinkoEngine, riskLevel, rowCount, winRecords } from '$lib/stores/game';
   import { isAnimationOn } from '$lib/stores/settings';
   import type { Action } from 'svelte/action';

--- a/src/lib/components/Plinko/PlinkoEngine.ts
+++ b/src/lib/components/Plinko/PlinkoEngine.ts
@@ -1,4 +1,4 @@
-import { binPayouts } from '$lib/constants/game';
+import { binPayouts as binPayoutsStore } from '$lib/stores/config';
 import {
   rowCount,
   winRecords,
@@ -256,7 +256,8 @@ class PlinkoEngine {
     const binIndex = this.pinsLastRowXCoords.findLastIndex((pinX) => pinX < ball.position.x);
     if (binIndex !== -1 && binIndex < this.pinsLastRowXCoords.length - 1) {
       const betAmount = get(betAmountOfExistingBalls)[ball.id] ?? 0;
-      const multiplier = binPayouts[this.rowCount][this.riskLevel][binIndex];
+      const payouts = get(binPayoutsStore);
+      const multiplier = payouts[this.rowCount][this.riskLevel][binIndex];
       const payoutValue = betAmount * multiplier;
       const profit = payoutValue - betAmount;
 

--- a/src/lib/stores/config.ts
+++ b/src/lib/stores/config.ts
@@ -1,0 +1,28 @@
+import { writable } from 'svelte/store';
+import { binPayouts as defaultBinPayouts } from '$lib/constants/game';
+import type { RiskLevel } from '$lib/types';
+import type { RowCount } from '$lib/constants/game';
+
+export const binPayouts = writable<Record<RowCount, Record<RiskLevel, number[]>>>(defaultBinPayouts);
+
+export async function fetchConfig() {
+  const endpoint = import.meta.env.VITE_CONFIG_ENDPOINT || '/api/config';
+  try {
+    const res = await fetch(endpoint, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: import.meta.env.VITE_CONFIG_TOKEN ? `Bearer ${import.meta.env.VITE_CONFIG_TOKEN}` : '',
+      },
+    });
+    if (res.ok) {
+      const data = await res.json();
+      if (data?.binPayouts) {
+        binPayouts.set(data.binPayouts);
+      }
+    } else {
+      console.error('Failed to fetch config', res.status);
+    }
+  } catch (err) {
+    console.error('Failed to fetch config', err);
+  }
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,9 +7,11 @@
   import Sidebar from '$lib/components/Sidebar';
   import { setBalanceFromLocalStorage, writeBalanceToLocalStorage } from '$lib/utils/game';
   import GitHubLogo from 'phosphor-svelte/lib/GithubLogo';
+  import { fetchConfig } from '$lib/stores/config';
 
   $effect(() => {
     setBalanceFromLocalStorage();
+    fetchConfig();
   });
 </script>
 

--- a/src/routes/api/config/+server.ts
+++ b/src/routes/api/config/+server.ts
@@ -1,0 +1,15 @@
+import { json } from '@sveltejs/kit';
+import { binPayouts as defaultBinPayouts } from '$lib/constants/game';
+
+export function GET() {
+  let payouts = defaultBinPayouts;
+  const env = process.env.BIN_PAYOUTS_JSON;
+  if (env) {
+    try {
+      payouts = JSON.parse(env);
+    } catch (err) {
+      console.error('Invalid BIN_PAYOUTS_JSON env');
+    }
+  }
+  return json({ binPayouts: payouts });
+}


### PR DESCRIPTION
## Summary
- add `binPayouts` store and load config from `/api/config`
- use runtime payouts in Plinko components
- fetch config on page load
- document backend configuration options

## Testing
- `pnpm test:unit --run`
- `pnpm build`
- `pnpm exec playwright test --reporter=line` *(fails: 18 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6841abb455c88330a17a94290a86f73b